### PR TITLE
Add `elm-test init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # node-elm-test
 Runs [elm-test](https://github.com/deadfoxygrandpa/Elm-Test) suites from Node.js
 
-Install it with `npm install -g elm-test`, then try this after downloading this repository:
+## Installation
 
 ```bash
-cd examples
-elm-package install --yes
-elm-test Test.elm
+npm install -g elm-test
 ```
+
+## Usage
+
+```bash
+elm-test init  # Adds the Elm-Test dependency and creates TestRunner.elm and Tests.elm
+elm-test TestRunner.elm  # Runs the tests
+```
+
+Then add your tests to Tests.elm.
 
 Also check out [`elm-check`](https://github.com/TheSeamau5/elm-check) for property-based testing via `elm-test`!

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -6,11 +6,29 @@ process.title = 'elm-test';
 
 var compile    = require("node-elm-compiler").compile,
   suffix       = require("../elm-io-ports.js"),
-  fs           = require("fs"),
+  fs           = require("fs-extra"),
+  path         = require("path"),
   temp         = require("temp").track(), // Automatically cleans up temp files.
   util         = require("util"),
   _            = require("lodash"),
   childProcess = require("child_process");
+
+if (process.argv[2] == "init") {
+  var copyTemplate = function(templateName) {
+    if (fs.existsSync(templateName)) {
+      console.log(templateName + " already exists");
+    } else {
+      fs.copySync(path.resolve(__dirname, "../templates/" + templateName), templateName);
+      console.log("Created " + templateName);
+    }
+  };
+
+  childProcess.execSync("elm package install deadfoxygrandpa/Elm-Test", {stdio:[0,1,2]});
+  childProcess.execSync("elm package install maxsnew/IO", {stdio:[0,1,2]});
+  copyTemplate("TestRunner.elm");
+  copyTemplate("Tests.elm");
+  process.exit(0);
+}
 
 var testFile   = process.argv[2],
     cwd        = __dirname;
@@ -22,7 +40,8 @@ function spawnCompiler(cmd, args, opts) {
 }
 
 if (typeof testFile !== "string") {
-  console.log("Usage: elm-test TESTFILE\n");
+  console.log("Usage: elm-test init  # Create example tests\n");
+  console.log("Usage: elm-test TESTFILE  # Run tests\n");
   process.exit(1);
 }
 

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -23,8 +23,17 @@ if (process.argv[2] == "init") {
     }
   };
 
-  childProcess.execSync("elm package install deadfoxygrandpa/Elm-Test", {stdio:[0,1,2]});
-  childProcess.execSync("elm package install maxsnew/IO", {stdio:[0,1,2]});
+  var elmOptions = "";
+  if (process.argv[3] == "--yes" || process.argv[3] == "-y") {
+    elmOptions += " --yes";
+  }
+
+  var execElmSync = function(command) {
+      childProcess.execSync(command + elmOptions, {stdio:[0,1,2]});
+  }
+
+  execElmSync("elm package install deadfoxygrandpa/Elm-Test");
+  execElmSync("elm package install maxsnew/IO");
   copyTemplate("TestRunner.elm");
   copyTemplate("Tests.elm");
   process.exit(0);
@@ -40,7 +49,7 @@ function spawnCompiler(cmd, args, opts) {
 }
 
 if (typeof testFile !== "string") {
-  console.log("Usage: elm-test init  # Create example tests\n");
+  console.log("Usage: elm-test init [--yes]  # Create example tests\n");
   console.log("Usage: elm-test TESTFILE  # Run tests\n");
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/rtfeldman/node-elm-test#readme",
   "dependencies": {
-    "fs-extra": "^0.23.1",
+    "fs-extra": "0.23.1",
     "lodash": "3.9.3",
     "node-elm-compiler": "0.4.0+elm-0.15.1",
     "temp": "0.8.1"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.3.0",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
-  "engines" : {
-    "node" : ">=0.12.0"
+  "engines": {
+    "node": ">=0.12.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/rtfeldman/node-elm-test#readme",
   "dependencies": {
+    "fs-extra": "^0.23.1",
     "lodash": "3.9.3",
     "node-elm-compiler": "0.4.0+elm-0.15.1",
     "temp": "0.8.1"

--- a/templates/TestRunner.elm
+++ b/templates/TestRunner.elm
@@ -1,17 +1,12 @@
 module Main where
 
-import Basics exposing (..)
-import Signal exposing (..)
+import Signal exposing (Signal)
 
-import ElmTest.Assertion as A exposing (assertEqual, assert)
-import ElmTest.Run as R
 import ElmTest.Runner.Console exposing (runDisplay)
-import ElmTest.Test exposing (..)
-import IO.IO exposing (..)
+import IO.IO exposing (IO)
 import IO.Runner exposing (Request, Response)
 import IO.Runner as Run
 
-import String
 import Tests
 
 console : IO ()

--- a/templates/TestRunner.elm
+++ b/templates/TestRunner.elm
@@ -1,0 +1,23 @@
+module Main where
+
+import Basics exposing (..)
+import Signal exposing (..)
+
+import ElmTest.Assertion as A exposing (assertEqual, assert)
+import ElmTest.Run as R
+import ElmTest.Runner.Console exposing (runDisplay)
+import ElmTest.Test exposing (..)
+import IO.IO exposing (..)
+import IO.Runner exposing (Request, Response)
+import IO.Runner as Run
+
+import String
+import Tests
+
+console : IO ()
+console = runDisplay Tests.all
+
+port requests : Signal Request
+port requests = Run.run responses console
+
+port responses : Signal Response

--- a/templates/Tests.elm
+++ b/templates/Tests.elm
@@ -7,8 +7,10 @@ import String
 
 
 all : Test
-all = suite "A Test Suite"
-        [ test "Addition" (assertEqual (3 + 7) 10)
-        , test "String.left" (assertEqual "a" (String.left 1 "abcdefg"))
-        , test "This test should fail" (assert False)
+all =
+    suite "A Test Suite"
+        [
+            test "Addition" (assertEqual (3 + 7) 10),
+            test "String.left" (assertEqual "a" (String.left 1 "abcdefg")),
+            test "This test should fail" (assert False)
         ]

--- a/templates/Tests.elm
+++ b/templates/Tests.elm
@@ -1,0 +1,14 @@
+module Tests where
+
+import ElmTest.Assertion as A exposing (assertEqual, assert)
+import ElmTest.Test exposing (..)
+
+import String
+
+
+all : Test
+all = suite "A Test Suite"
+        [ test "Addition" (assertEqual (3 + 7) 10)
+        , test "String.left" (assertEqual "a" (String.left 1 "abcdefg"))
+        , test "This test should fail" (assert False)
+        ]


### PR DESCRIPTION
Make it easier to get started with testing by adding `elm-test init`, which does the following:

1. `elm package install deadfoxygrandpa/Elm-Test`
1. `elm package install maxsnew/IO`
1. Creates `TestRunner.elm` and `Tests.elm` with example tests.