### PR TITLE
Support Elm 0.16 and elm-test 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
 sudo: false
 
-language: node_js
-node_js:
-  - "0.12"
+env:
+  matrix:
+    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
+    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.10
 
-addons:
-  apt:
-    sources:
-    - hvr-ghc
-    packages:
-    - cabal-install-1.22
-    - ghc-7.10.1
+install:
+  - nvm install $TARGET_NODE_VERSION
+  - nvm use $TARGET_NODE_VERSION
+  - node --version
+  - npm --version
+  - npm install -g elm@$ELM_VERSION
 
-
-before_install:
- - export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:./Elm-Platform/0.15.1/.cabal-sandbox/bin:$PATH
- - runhaskell BuildFromSource.hs 0.15.1
- - export PATH="`pwd`"/Elm-Platform/0.15.1/.cabal-sandbox/bin:$PATH
+script: ./ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 env:
   matrix:
     - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
-    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.10
+    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.12
 
 install:
   - nvm install $TARGET_NODE_VERSION

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -17,6 +17,11 @@ var elm = {
   'elm-package': 'elm-package'
 };
 
+if (process.argv[2] == "--version") {
+  console.log(require(path.join(__dirname, "..", "package.json")).version);
+  process.exit(0);
+}
+
 if (process.argv[2] == "init") {
   var copyTemplate = function(templateName) {
     if (fs.existsSync(templateName)) {

--- a/ci.sh
+++ b/ci.sh
@@ -23,6 +23,9 @@ function assertTestSuccess() {
 echo "$0: Installing elm-test..."
 npm install --global
 
+echo "$0: Verifying installed elm-test version..."
+elm-test --version
+
 echo "$0: Testing examples..."
 cd examples
 assertTestSuccess PassingTests.elm

--- a/examples/FailingTests.elm
+++ b/examples/FailingTests.elm
@@ -3,10 +3,7 @@ module Main where
 import Basics exposing (..)
 import Signal exposing (..)
 
-import ElmTest.Assertion as A exposing (assertEqual, assert)
-import ElmTest.Run as R
-import ElmTest.Runner.Console exposing (runDisplay)
-import ElmTest.Test exposing (..)
+import ElmTest exposing (..)
 import Console exposing (IO, run)
 import Task
 import String
@@ -19,7 +16,7 @@ tests = suite "A Test Suite"
         ]
 
 console : IO ()
-console = runDisplay tests
+console = consoleRunner tests
 
 port runner : Signal (Task.Task x ())
 port runner = run console

--- a/examples/PassingTests.elm
+++ b/examples/PassingTests.elm
@@ -3,10 +3,7 @@ module Main where
 import Basics exposing (..)
 import Signal exposing (..)
 
-import ElmTest.Assertion as A exposing (assertEqual, assert)
-import ElmTest.Run as R
-import ElmTest.Runner.Console exposing (runDisplay)
-import ElmTest.Test exposing (..)
+import ElmTest exposing (..)
 import Console exposing (IO, run)
 import Task
 import String
@@ -18,7 +15,7 @@ tests = suite "A Test Suite"
         ]
 
 console : IO ()
-console = runDisplay tests
+console = consoleRunner tests
 
 port runner : Signal (Task.Task x ())
 port runner = run console

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -8,7 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "deadfoxygrandpa/elm-test": "2.0.0 <= v < 3.0.0",
+        "deadfoxygrandpa/elm-test": "2.0.0 <= v < 4.0.0",
         "elm-lang/core": "2.0.0 <= v < 4.0.0",
         "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0"
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   },
   "scripts": {
     "test": "./ci.sh"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.6.5",
+  "version": "0.16.0-beta",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/templates/TestRunner.elm
+++ b/templates/TestRunner.elm
@@ -2,14 +2,14 @@ module Main where
 
 import Signal exposing (Signal)
 
-import ElmTest.Runner.Console exposing (runDisplay)
+import ElmTest exposing (consoleRunner)
 import Console exposing (IO, run)
 import Task
 
 import Tests
 
 console : IO ()
-console = runDisplay Tests.all
+console = consoleRunner Tests.all
 
 port runner : Signal (Task.Task x ())
 port runner = run console

--- a/templates/Tests.elm
+++ b/templates/Tests.elm
@@ -1,7 +1,6 @@
 module Tests where
 
-import ElmTest.Assertion exposing (..)
-import ElmTest.Test exposing (..)
+import ElmTest exposing (..)
 
 import String
 


### PR DESCRIPTION
Also make Travis do more comprehensive tests.

This will mostly fix https://github.com/rtfeldman/node-elm-test/issues/16 - although will want to let people try out the beta release and kick the tires a bit before publishing the final 0.16.0.