### PR TITLE
Disallow elm-test 2.0.0

### DIFF
--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -8,7 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "deadfoxygrandpa/elm-test": "2.0.0 <= v < 4.0.0",
+        "deadfoxygrandpa/elm-test": "3.0.0 <= v < 4.0.0",
         "elm-lang/core": "2.0.0 <= v < 4.0.0",
         "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0"
     },


### PR DESCRIPTION
You've changed the imports and everything for elm-test 3.0.0, so it won't work with anything less than 3.0.0 anymore.