### PR TITLE
Use cross-spawn instead of child_process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 sudo: false
 
+os:
+  - linux
+  - osx
+
 env:
   matrix:
     - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
     - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.12
+
+before_install:
+  - if [ ${TRAVIS_OS_NAME} == "osx" ];
+    then brew update; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh;
+    fi
 
 install:
   - nvm install $TARGET_NODE_VERSION
@@ -11,5 +20,7 @@ install:
   - node --version
   - npm --version
   - npm install -g elm@$ELM_VERSION
+  - npm install
 
-script: ./ci.sh
+script:
+  - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ install:
   - npm install -g elm@%ELM_VERSION%
   - npm install
 
-test_script: ci.sh
+test_script:
+  - npm test
 
 build: off

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -38,7 +38,17 @@ if (process.argv[2] == "init") {
   }
 
   var spawnElmPackageSync = function(command) {
-      spawn.sync(elm["elm-package"] + " " + command + elmOptions, {stdio:[0,1,2]});
+    var status =
+      spawn.sync(
+        elm["elm-package"] + " " + command + elmOptions,
+        {stdio:[0,1,2]}
+      ).status;
+
+    if (status) {
+      console.error("Error: " + command + " returned status code " + status);
+
+      process.exit(status);
+    }
   }
 
   copyTemplate("elm-package.json");

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -11,7 +11,7 @@ var compile    = require("node-elm-compiler").compile,
   temp         = require("temp").track(), // Automatically cleans up temp files.
   util         = require("util"),
   _            = require("lodash"),
-  childProcess = require("child_process");
+  spawn        = require("cross-spawn");
 
 var elm = {
   'elm-package': 'elm-package'
@@ -37,13 +37,13 @@ if (process.argv[2] == "init") {
     elmOptions += " --yes";
   }
 
-  var execElmPackageSync = function(command) {
-      childProcess.execSync(elm["elm-package"] + " " + command + elmOptions, {stdio:[0,1,2]});
+  var spawnElmPackageSync = function(command) {
+      spawn.sync(elm["elm-package"] + " " + command + elmOptions, {stdio:[0,1,2]});
   }
 
   copyTemplate("elm-package.json");
-  execElmPackageSync("install deadfoxygrandpa/elm-test");
-  execElmPackageSync("install laszlopandy/elm-console");
+  spawnElmPackageSync("install deadfoxygrandpa/elm-test");
+  spawnElmPackageSync("install laszlopandy/elm-console");
   copyTemplate("TestRunner.elm");
   copyTemplate("Tests.elm");
   process.exit(0);
@@ -56,7 +56,7 @@ var testFile = process.argv[2],
 function spawnCompiler(cmd, args, opts) {
   var compilerOpts = _.defaults({stdio: "inherit"}, opts);
 
-  return childProcess.spawn(cmd, args, compilerOpts);
+  return spawn(cmd, args, compilerOpts);
 }
 
 if (typeof testFile !== "string") {
@@ -92,7 +92,7 @@ temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
     console.log("Successfully compiled", testFile);
 
     var runnerOpts = {stdio: ["pipe", "inherit", "inherit"]};
-    var runnerProcess = childProcess.spawn("node", [], runnerOpts);
+    var runnerProcess = spawn("node", [], runnerOpts);
 
     runnerProcess.on('exit', function (exitCode) {
       process.exit(exitCode);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.16.1-alpha",
+  "version": "0.16.1-alpha2",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/rtfeldman/node-elm-test#readme",
   "dependencies": {
+    "cross-spawn": "2.1.0",
     "fs-extra": "0.26.2",
     "lodash": "3.10.1",
     "node-elm-compiler": "2.3.2",

--- a/templates/elm-package.json
+++ b/templates/elm-package.json
@@ -1,14 +1,16 @@
 {
     "version": "1.0.0",
-    "summary": "helpful summary of your project, less than 80 characters",
+    "summary": "Sample Elm Test",
     "repository": "https://github.com/user/project.git",
-    "license": "BSD3",
+    "license": "BSD-3-Clause",
     "source-directories": [
         "."
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 4.0.0"
+        "deadfoxygrandpa/elm-test": "3.0.0 <= v < 4.0.0",
+        "elm-lang/core": "2.0.0 <= v < 4.0.0",
+        "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0"
     },
     "elm-version": "0.15.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
Fixes an `ENOENT` bug on Windows - see https://github.com/rtfeldman/node-elm-compiler/pull/12